### PR TITLE
Re-introduce backtraces in OCaml code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -722,8 +722,11 @@ ocamlrund_CPPFLAGS = -DDEBUG
 ocamlruni_CPPFLAGS = -DCAML_INSTR
 
 # Debug runtime: compile with ThreadSanitizer. Don't optimize too much to get
-# better backtraces of errors.
-OC_NATIVE_DEBUG_CFLAGS = -O1 -fno-omit-frame-pointer -fsanitize=thread
+# better backtraces of errors. Compile as PIE as this might be necessary to get
+# line numbers in backtraces (unclear).
+# Avoid DWARF 5 which is not understood by some tools (like binutils 2.38).
+OC_NATIVE_DEBUG_CFLAGS = -O1 -fno-omit-frame-pointer -fsanitize=thread -g \
+  -gdwarf-4 -fPIE -Wno-tsan
 
 ## Runtime targets
 

--- a/asmcomp/CSEgen.ml
+++ b/asmcomp/CSEgen.ml
@@ -237,6 +237,7 @@ method class_of_operation op =
   | Ifloatofint | Iintoffloat -> Op_pure
   | Ispecific _ -> Op_other
   | Idls_get -> Op_load Mutable
+  | Ireturn_addr -> Op_load Immutable
 
 (* Operations that are so cheap that it isn't worth factoring them. *)
 method is_cheap_operation op =

--- a/asmcomp/afl_instrument.ml
+++ b/asmcomp/afl_instrument.ml
@@ -97,7 +97,7 @@ and instrument = function
 
   (* these are base cases and have no logging *)
   | Cconst_int _ | Cconst_natint _ | Cconst_float _
-  | Cconst_symbol _
+  | Cconst_symbol _ | Creturn_addr
   | Cvar _ as c -> c
 
 let instrument_function c dbg =

--- a/asmcomp/amd64/emit.mlp
+++ b/asmcomp/amd64/emit.mlp
@@ -741,6 +741,9 @@ let emit_instr env fallthrough i =
       I.mov (arg32 i 0) (res32 i 0)
   | Lop (Idls_get) ->
       I.mov (domain_field Domainstate.Domain_dls_root) (res i 0)
+  | Lop (Ireturn_addr) ->
+      let offset = frame_size env - 8 in
+      I.mov (mem64 QWORD offset RSP) (res i 0)
   | Lreloadretaddr ->
       ()
   | Lreturn ->

--- a/asmcomp/cmm.ml
+++ b/asmcomp/cmm.ml
@@ -197,6 +197,7 @@ type expression =
   | Cexit of int * expression list
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
       * Debuginfo.t
+  | Creturn_addr
 
 type codegen_option =
   | Reduce_code_size
@@ -266,7 +267,8 @@ let iter_shallow_tail f = function
   | Cvar _
   | Cassign _
   | Ctuple _
-  | Cop _ ->
+  | Cop _
+  | Creturn_addr ->
       false
 
 let rec map_tail f = function
@@ -302,6 +304,7 @@ let rec map_tail f = function
   | Cvar _
   | Cassign _
   | Ctuple _
+  | Creturn_addr
   | Cop _ as c ->
       f c
 
@@ -336,5 +339,6 @@ let map_shallow f = function
   | Cconst_float _
   | Cconst_symbol _
   | Cvar _
+  | Creturn_addr
     as c ->
       c

--- a/asmcomp/cmm.mli
+++ b/asmcomp/cmm.mli
@@ -199,6 +199,7 @@ and expression =
   | Cexit of int * expression list
   | Ctrywith of expression * Backend_var.With_provenance.t * expression
       * Debuginfo.t
+  | Creturn_addr (** Return address saved in the current call frame *)
 
 type codegen_option =
   | Reduce_code_size

--- a/asmcomp/cmm_invariants.ml
+++ b/asmcomp/cmm_invariants.ml
@@ -125,7 +125,7 @@ end
 let rec check env (expr : Cmm.expression) =
   match expr with
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
-  | Cvar _ ->
+  | Cvar _ | Creturn_addr ->
     ()
   | Clet (_, expr, body)
   | Clet_mut (_, _, expr, body) ->

--- a/asmcomp/mach.ml
+++ b/asmcomp/mach.ml
@@ -66,6 +66,7 @@ type operation =
   | Ispecific of Arch.specific_operation
   | Ipoll of { return_label: Cmm.label option }
   | Idls_get
+  | Ireturn_addr
 
 type instruction =
   { desc: instruction_desc;

--- a/asmcomp/mach.mli
+++ b/asmcomp/mach.mli
@@ -67,6 +67,7 @@ type operation =
   | Ispecific of Arch.specific_operation
   | Ipoll of { return_label: Cmm.label option }
   | Idls_get
+  | Ireturn_addr (** Retrieve the return address from the stack frame *)
 
 type instruction =
   { desc: instruction_desc;

--- a/asmcomp/polling.ml
+++ b/asmcomp/polling.ml
@@ -259,7 +259,7 @@ let find_poll_alloc_or_calls instr =
             Iconst_symbol _ | Iextcall { alloc = false } | Istackoffset _ |
             Iload _ | Istore _ | Iintop _ | Iintop_imm _ | Ifloatofint |
             Iintoffloat | Inegf | Iabsf | Iaddf | Isubf | Imulf | Idivf |
-            Iopaque | Ispecific _ | Idls_get) -> None
+            Iopaque | Ispecific _ | Idls_get | Ireturn_addr) -> None
       | Iend | Ireturn | Iifthenelse _ | Iswitch _ | Icatch _ | Iexit _ |
         Itrywith _ | Iraise _ -> None
     in

--- a/asmcomp/printcmm.ml
+++ b/asmcomp/printcmm.ml
@@ -167,6 +167,7 @@ let rec expr ppf = function
   | Cconst_float (n, _dbg) -> fprintf ppf "%F" n
   | Cconst_symbol (s, _dbg) -> fprintf ppf "\"%s\"" s
   | Cvar id -> V.print ppf id
+  | Creturn_addr -> fprintf ppf "return_addr"
   | Clet(id, def, (Clet(_, _, _) as body)) ->
       let print_binding id ppf def =
         fprintf ppf "@[<2>%a@ %a@]"

--- a/asmcomp/printmach.ml
+++ b/asmcomp/printmach.ml
@@ -155,6 +155,7 @@ let operation op arg ppf res =
   | Ispecific op ->
       Arch.print_specific_operation reg op ppf arg
   | Idls_get -> fprintf ppf "dls_get"
+  | Ireturn_addr -> fprintf ppf "return_addr"
   | Ipoll { return_label } ->
       fprintf ppf "poll call";
       match return_label with

--- a/asmcomp/selectgen.ml
+++ b/asmcomp/selectgen.ml
@@ -316,6 +316,7 @@ method is_simple_expr = function
   | Cconst_float _ -> true
   | Cconst_symbol _ -> true
   | Cvar _ -> true
+  | Creturn_addr -> true
   | Ctuple el -> List.for_all self#is_simple_expr el
   | Clet(_id, arg, body) | Clet_mut(_id, _, arg, body) ->
     self#is_simple_expr arg && self#is_simple_expr body
@@ -351,7 +352,7 @@ method effects_of exp =
   let module EC = Effect_and_coeffect in
   match exp with
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
-  | Cvar _ -> EC.none
+  | Cvar _ | Creturn_addr -> EC.none
   | Ctuple el -> EC.join_list_map el self#effects_of
   | Clet (_id, arg, body) | Clet_mut (_id, _, arg, body) ->
     EC.join (self#effects_of arg) (self#effects_of body)
@@ -630,6 +631,9 @@ method emit_expr (env:environment) exp =
          adding this register to the frame table would be redundant *)
       let r = self#regs_for typ_int in
       Some(self#insert_op env (Iconst_symbol n) [||] r)
+  | Creturn_addr ->
+      let r = self#regs_for typ_int in
+      Some(self#insert_op env Ireturn_addr [||] r)
   | Cvar v ->
       begin try
         Some(env_find v env)
@@ -1154,6 +1158,7 @@ method emit_tail (env:environment) exp =
   | Cop _
   | Cconst_int _ | Cconst_natint _ | Cconst_float _ | Cconst_symbol _
   | Cvar _
+  | Creturn_addr
   | Cassign _
   | Ctuple _
   | Cexit _ ->

--- a/asmcomp/thread_sanitizer.mli
+++ b/asmcomp/thread_sanitizer.mli
@@ -13,5 +13,17 @@
 (*                                                                        *)
 (**************************************************************************)
 
+(** Instrumentation of memory accesses using ThreadSanitizer for data race
+    detection. This module contains an instrumentation pass on Cmm, where most
+    of the instrumentation happens.
+    Only, the function prologues and epilogues are instrumented at the assembly
+    level (architecture-specific, due to the need to pass the return address)
+    where calls are emitted to [__tsan_func_entry] and [__tsan_func_exit]. *)
+
+(** Instrumentation of a {!Cmm.expression}. *)
 val instrument : string -> Cmm.expression -> Cmm.expression
+
+(** Call to [__tsan_init], which should be called at least once in the compiled
+    program, before other [__tsan_*] API functions. Idempotent, i.e. can be
+    called more than once without consequences. *)
 val init_code : unit -> Cmm.expression

--- a/dune
+++ b/dune
@@ -160,7 +160,7 @@
    polling printcmm printlinear printmach proc
    reg reload reloadgen
    schedgen scheduling selectgen selection spill split
-   strmatch x86_ast x86_dsl x86_gas x86_masm x86_proc
+   strmatch thread_sanitizer x86_ast x86_dsl x86_gas x86_masm x86_proc
 
    ;; file_formats/
    linear_format


### PR DESCRIPTION
Re-introduce backtraces in OCaml code including in the presence of tail calls. This was done together with @fabbing.

We may want to improve this as currently it pushes all caller-saved registers (in the System V convention) on the stack before calling `__tsan_func_{entry,exit}`, and pops them right after. That is both costly and not adapted to other systems with other calling conventions.

If there is a more generic approach to this, i.e. not architecture-specific, it would be interesting.