### PR TITLE
Remove instrumentation in bytecode backend, 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,7 +169,6 @@ META
 /runtime/ocamlrun
 /runtime/ocamlrund
 /runtime/ocamlruni
-/runtime/ocamlrunt
 /runtime/ld.conf
 /runtime/.gdb_history
 /runtime/build_config.h
@@ -179,8 +178,8 @@ META
 
 /stdlib/camlheader
 /stdlib/target_camlheader
-/stdlib/camlheader[dit]
-/stdlib/target_camlheader[dit]
+/stdlib/camlheader[di]
+/stdlib/target_camlheader[di]
 /stdlib/camlheader_ur
 /stdlib/labelled-*
 /stdlib/caml

--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,12 @@ else
   COLDSTART_DEPS = boot/ocamlruns$(EXE)
 endif
 
+ifeq "$(WITH_TSAN)" "true"
+OC_NATIVE_CPPFLAGS += $(OC_TSAN_CPPFLAGS)
+OC_NATIVE_CFLAGS += $(OC_TSAN_CFLAGS)
+OC_ASPPFLAGS += $(OC_TSAN_ASPPFLAGS)
+endif
+
 expunge := expunge$(EXE)
 
 # targets for the compilerlibs/*.{cma,cmxa} archives
@@ -499,7 +505,7 @@ beforedepend:: parsing/lexer.ml
 
 ocamlc.opt$(EXE): compilerlibs/ocamlcommon.cmxa \
                   compilerlibs/ocamlbytecomp.cmxa $(BYTESTART:.cmo=.cmx)
-	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)" -I runtime
+	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^ -cclib "$(BYTECCLIBS)"
 
 partialclean::
 	rm -f ocamlc.opt$(EXE)
@@ -510,7 +516,7 @@ ocamlopt.opt$(EXE): \
                     compilerlibs/ocamlcommon.cmxa \
                     compilerlibs/ocamloptcomp.cmxa \
                     $(OPTSTART:.cmo=.cmx)
-	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^ -I runtime
+	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^
 
 partialclean::
 	rm -f ocamlopt.opt$(EXE)
@@ -682,12 +688,6 @@ runtime_BYTECODE_STATIC_LIBRARIES += runtime/libcamlruni.$(A)
 runtime_NATIVE_STATIC_LIBRARIES += runtime/libasmruni.$(A)
 endif
 
-ifeq "$(WITH_TSAN)" "true"
-runtime_PROGRAMS += runtime/ocamlrunt$(EXE)
-runtime_BYTECODE_STATIC_LIBRARIES += runtime/libcamlrunt.$(A)
-runtime_NATIVE_STATIC_LIBRARIES += runtime/libasmrunt.$(A)
-endif
-
 ifeq "$(UNIX_OR_WIN32)" "unix"
 ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
 runtime_BYTECODE_STATIC_LIBRARIES += runtime/libcamlrun_pic.$(A)
@@ -712,8 +712,6 @@ libcamlruni_OBJECTS = $(runtime_BYTECODE_C_SOURCES:.c=.bi.$(O))
 
 libcamlrunpic_OBJECTS = $(runtime_BYTECODE_C_SOURCES:.c=.bpic.$(O))
 
-libcamlrunt_OBJECTS = $(runtime_BYTECODE_C_SOURCES:.c=.bt.$(O))
-
 libasmrun_OBJECTS = \
   $(runtime_NATIVE_C_SOURCES:.c=.n.$(O)) $(runtime_ASM_OBJECTS)
 
@@ -726,15 +724,11 @@ libasmruni_OBJECTS = \
 libasmrunpic_OBJECTS = $(runtime_NATIVE_C_SOURCES:.c=.npic.$(O)) \
   $(runtime_ASM_OBJECTS:.$(O)=_libasmrunpic.$(O))
 
-libasmrunt_OBJECTS = \
-  $(runtime_NATIVE_C_SOURCES:.c=.nt.$(O)) $(runtime_ASM_OBJECTS:.$(O)=.t.$(O))
-
 ## General (non target-specific) assembler and compiler flags
 
 runtime_CPPFLAGS = -DCAMLDLLIMPORT=
 ocamlrund_CPPFLAGS = -DDEBUG
 ocamlruni_CPPFLAGS = -DCAML_INSTR
-ocamlrunt_CPPFLAGS = -DWITH_THREAD_SANITIZER
 
 ## Runtime targets
 
@@ -856,12 +850,6 @@ runtime/ocamlruni$(EXE): runtime/prims.$(O) runtime/libcamlruni.$(A)
 runtime/libcamlruni.$(A): $(libcamlruni_OBJECTS)
 	$(call MKLIB,$@, $^)
 
-runtime/ocamlrunt$(EXE): runtime/prims.$(O) runtime/libcamlrunt.$(A)
-	$(MKEXE) -o $@ $^ $(TSAN_RUNTIME_LIBS) $(BYTECCLIBS)
-
-runtime/libcamlrunt.$(A): $(libcamlrunt_OBJECTS)
-	$(call MKLIB,$@, $^)
-
 runtime/libcamlrun_pic.$(A): $(libcamlrunpic_OBJECTS)
 	$(call MKLIB,$@, $^)
 
@@ -878,9 +866,6 @@ runtime/libasmruni.$(A): $(libasmruni_OBJECTS)
 	$(call MKLIB,$@, $^)
 
 runtime/libasmrun_pic.$(A): $(libasmrunpic_OBJECTS)
-	$(call MKLIB,$@, $^)
-
-runtime/libasmrunt.$(A): $(libasmrunt_OBJECTS)
 	$(call MKLIB,$@, $^)
 
 runtime/libasmrun_shared.$(SO): $(libasmrunpic_OBJECTS)
@@ -900,29 +885,24 @@ $(DEPDIR)/runtime/%.bi.$(D): OC_CPPFLAGS += $(ocamlruni_CPPFLAGS)
 runtime/%.bpic.$(O): OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 $(DEPDIR)/runtime/%.bpic.$(D): OC_CFLAGS += $(SHAREDLIB_CFLAGS)
 
-runtime/%.bt.$(O): OC_CPPFLAGS += $(ocamlrunt_CPPFLAGS)
-runtime/%.bt.$(O): OC_CFLAGS += $(OC_TSAN_CFLAGS)
-$(DEPDIR)/runtime/%.bt.$(D): OC_CPPFLAGS += $(ocamlrunt_CPPFLAGS)
-
 runtime/%.n.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
+runtime/%.n.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
 $(DEPDIR)/runtime/%.n.$(D): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS)
 
 runtime/%.nd.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlrund_CPPFLAGS)
+runtime/%.nd.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
 $(DEPDIR)/runtime/%.nd.$(D): \
   OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlrund_CPPFLAGS)
 
 runtime/%.ni.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
+runtime/%.ni.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
 $(DEPDIR)/runtime/%.ni.$(D): \
   OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlruni_CPPFLAGS)
 
 runtime/%.npic.$(O): OC_CFLAGS += $(OC_NATIVE_CPPFLAGS) $(SHAREDLIB_CFLAGS)
+runtime/%.npic.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS)
 $(DEPDIR)/runtime/%.npic.$(D): \
   OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(SHAREDLIB_CFLAGS)
-
-runtime/%.nt.$(O): OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlrunt_CPPFLAGS)
-runtime/%.nt.$(O): OC_CFLAGS += $(OC_NATIVE_CFLAGS) $(OC_TSAN_CFLAGS)
-$(DEPDIR)/runtime/%.nt.$(D): \
-  OC_CPPFLAGS += $(OC_NATIVE_CPPFLAGS) $(ocamlrunt_CPPFLAGS)
 
 ## Compilation of runtime C files
 
@@ -956,9 +936,9 @@ endef
 $(DEPDIR)/runtime:
 	$(MKDIR) $@
 
-runtime_OBJECT_TYPES = % %.b %.bd %.bi %.bpic %.bt
+runtime_OBJECT_TYPES = % %.b %.bd %.bi %.bpic
 ifneq "$(NATIVE_COMPILER)" "false"
-runtime_OBJECT_TYPES += %.n %.nd %.ni %.np %.npic %.nt
+runtime_OBJECT_TYPES += %.n %.nd %.ni %.np %.npic
 endif
 
 $(foreach runtime_OBJECT_TYPE, $(runtime_OBJECT_TYPES), \
@@ -989,11 +969,6 @@ runtime/%.d.o: runtime/%.S
 
 runtime/%.i.o: runtime/%.S
 	$(ASPP) $(OC_ASPPFLAGS) $(OC_INSTR_CPPFLAGS) -o $@ $< || $(ASPP_ERROR)
-
-runtime/%.t.o: runtime/%.S
-	$(ASPP) $(OC_ASPPFLAGS) $(OC_TSAN_ASPPFLAGS) $(OC_TSAN_CPPFLAGS) \
-	    $(ocamlrunt_CPPFLAGS) -o $@ $< \
-	  || $(ASPP_ERROR)
 
 runtime/%_libasmrunpic.o: runtime/%.S
 	$(ASPP) $(OC_ASPPFLAGS) $(SHAREDLIB_CFLAGS) -o $@ $<
@@ -1036,8 +1011,7 @@ runtime_DEP_FILES += $(addsuffix .n, $(basename $(runtime_NATIVE_C_SOURCES)))
 endif
 runtime_DEP_FILES += $(addsuffix d, $(runtime_DEP_FILES)) \
              $(addsuffix i, $(runtime_DEP_FILES)) \
-             $(addsuffix pic, $(runtime_DEP_FILES)) \
-             $(addsuffix t, $(runtime_DEP_FILES))
+             $(addsuffix pic, $(runtime_DEP_FILES))
 runtime_DEP_FILES := $(addsuffix .$(D), $(runtime_DEP_FILES))
 
 ifeq "$(COMPUTE_DEPS)" "true"
@@ -1061,10 +1035,9 @@ stdlib/libcamlrun.$(A): runtime-all
 	cd stdlib; $(LN) ../runtime/libcamlrun.$(A) .
 clean::
 	rm -f $(addprefix runtime/, *.o *.obj *.a *.lib *.so *.dll ld.conf)
-	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns \
-	  ocamlrunt sak)
+	rm -f $(addprefix runtime/, ocamlrun ocamlrund ocamlruni ocamlruns sak)
 	rm -f $(addprefix runtime/, ocamlrun.exe ocamlrund.exe ocamlruni.exe \
-	  ocamlrunt.exe ocamlruns.exe sak.exe)
+	  ocamlruns.exe sak.exe)
 	rm -f runtime/primitives runtime/primitives.new runtime/prims.c \
 	  $(runtime_BUILT_HEADERS)
 	rm -f runtime/domain_state*.inc
@@ -1360,8 +1333,7 @@ ocamlnat_dependencies := \
   $(TOPLEVELSTART:.cmo=.cmx)
 
 ocamlnat$(EXE): $(ocamlnat_dependencies)
-	$(CAMLOPT_CMD) $(LINKFLAGS) -linkall -I toplevel/native -o $@ $^ \
-	  -I runtime
+	$(CAMLOPT_CMD) $(LINKFLAGS) -linkall -I toplevel/native -o $@ $^
 
 toplevel/topdirs.cmx: toplevel/topdirs.ml
 	$(CAMLOPT_CMD) $(COMPFLAGS) $(OPTCOMPFLAGS) -I toplevel/native -c $<

--- a/Makefile.common
+++ b/Makefile.common
@@ -102,9 +102,14 @@ ALL_OTHERLIBS = dynlink str systhreads unix runtime_events
 OC_NATIVE_CPPFLAGS=\
   -DNATIVE_CODE -DTARGET_$(ARCH) -DMODEL_$(MODEL) -DSYS_$(SYSTEM)
 
+# The following variable defines flags to be passed to the C compiler
+# when compiling C files for the native runtime.
+# These flags should be passed *in addition* to those in OC_CFLAGS, they
+# should not repace them.
+OC_NATIVE_CFLAGS=
+
 # Flags to pass to the C preprocessor when preprocessing assembly files
 OC_ASPPFLAGS=-I $(ROOTDIR)/runtime $(OC_NATIVE_CPPFLAGS)
-OC_TSAN_ASPPFLAGS += -DWITH_THREAD_SANITIZER
 
 OPTCOMPFLAGS=
 ifeq "$(FUNCTION_SECTIONS)" "true"

--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -182,6 +182,8 @@ INSTALL_SOURCE_ARTIFACTS=@install_source_artifacts@
 
 OC_CFLAGS=@oc_cflags@
 OC_TSAN_CFLAGS=@oc_tsan_cflags@
+OC_TSAN_ASPPFLAGS=@oc_tsan_asppflags@
+OC_TSAN_CPPFLAGS=@oc_tsan_cppflags@
 CFLAGS?=@CFLAGS@
 OC_CPPFLAGS=-I$(ROOTDIR)/runtime @oc_cppflags@
 CPPFLAGS?=@CPPFLAGS@

--- a/asmcomp/thread_sanitizer.ml
+++ b/asmcomp/thread_sanitizer.ml
@@ -103,10 +103,10 @@ let wrap_entry_exit expr =
     | Ctrywith (e, v, handler, dbg_none) ->
         (* This is a [try ... with] in tail position. We need to insert a call
            to [__tsan_func_exit] at the tail of both the body and the handler.
-           However, these expressions are no longer in tail position (as code
-           is inserted at the end of a [try ... with] block to pop the
-           exception handler. *)
-        Ctrywith (insert_call_exit false e, v, insert_call_exit false handler, dbg_none)
+           However, the body expression is not in tail position (as code is
+           inserted at the end of it to pop the exception handler). The handler
+           expression is still in tail position. *)
+        Ctrywith (insert_call_exit false e, v, insert_call_exit true handler, dbg_none)
     | Cop (Capply fn, args, dbg_none) when is_tail ->
         (* This is a tail call. We insert the call to [__tsan_func_exit] right
            before the call, but after evaluating the arguments. *)

--- a/configure
+++ b/configure
@@ -840,6 +840,8 @@ bytecclibs
 oc_dll_ldflags
 oc_ldflags
 oc_cppflags
+oc_tsan_cppflags
+oc_tsan_asppflags
 oc_tsan_cflags
 oc_cflags
 toolchain
@@ -3196,6 +3198,8 @@ ocamlc_cppflags=""
 oc_ldflags=""
 oc_dll_ldflags=""
 oc_tsan_cflags="-O1 -fno-omit-frame-pointer -fsanitize=thread"
+oc_tsan_cppflags="-DWITH_THREAD_SANITIZER"
+oc_tsan_asppflags="-DWITH_THREAD_SANITIZER"
 ostype="Unix"
 SO="so"
 toolchain="cc"
@@ -3242,6 +3246,8 @@ OCAML_VERSION_SHORT=5.1
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
+
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,8 @@ ocamlc_cppflags=""
 oc_ldflags=""
 oc_dll_ldflags=""
 oc_tsan_cflags="-O1 -fno-omit-frame-pointer -fsanitize=thread"
+oc_tsan_cppflags="-DWITH_THREAD_SANITIZER"
+oc_tsan_asppflags="-DWITH_THREAD_SANITIZER"
 ostype="Unix"
 SO="so"
 toolchain="cc"
@@ -118,6 +120,8 @@ AC_SUBST([ccomptype])
 AC_SUBST([toolchain])
 AC_SUBST([oc_cflags])
 AC_SUBST([oc_tsan_cflags])
+AC_SUBST([oc_tsan_asppflags])
+AC_SUBST([oc_tsan_cppflags])
 AC_SUBST([oc_cppflags])
 AC_SUBST([oc_ldflags])
 AC_SUBST([oc_dll_ldflags])

--- a/driver/compenv.ml
+++ b/driver/compenv.ml
@@ -696,10 +696,7 @@ let action_of_file name =
   else
     ProcessOtherFile name
 
-let deferred_actions =
-  ref (if Config.tsan
-       then [ProcessObjects ["-fsanitize=thread"; "-lunwind"]]
-       else [])
+let deferred_actions = ref []
 let defer action =
   deferred_actions := action :: !deferred_actions
 

--- a/driver/main_args.ml
+++ b/driver/main_args.ml
@@ -1737,10 +1737,7 @@ module Default = struct
     let _pack = set make_package
     let _plugin _p = plugin := true
     let _pp s = preprocessor := (Some s)
-    let _runtime_variant s =
-      if Config.tsan && not (List.mem s ["";"t"]) then
-        Compenv.fatal "Cannot use another runtime with `-tsan`";
-      runtime_variant := s
+    let _runtime_variant s = runtime_variant := s
     let _stop_after pass =
       let module P = Compiler_pass in
         match P.of_string pass with

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -49,6 +49,8 @@ let main argv ppf =
     Compmisc.read_clflags_from_env ();
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
+    if Config.tsan then
+      Compenv.(defer (ProcessObjects ["-fsanitize=thread"; "-lunwind"]));
     begin try
       Compenv.process_deferred_actions
         (ppf,

--- a/lex/Makefile
+++ b/lex/Makefile
@@ -52,7 +52,7 @@ ocamllex$(EXE): $(OBJS)
 	$(CAMLC) $(LINKFLAGS) -compat-32 -o $@ $^
 
 ocamllex.opt$(EXE): $(OBJS:.cmo=.cmx)
-	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^ -I ../runtime
+	$(CAMLOPT_CMD) $(LINKFLAGS) -o $@ $^
 
 clean::
 	rm -f $(programs) $(programs:=.exe)

--- a/ocamldoc/Makefile
+++ b/ocamldoc/Makefile
@@ -169,8 +169,7 @@ $(OCAMLDOC): $(EXECMOFILES)
 $(eval $(call PROGRAM_SYNONYM,ocamldoc.opt))
 
 $(OCAMLDOC_OPT): $(EXECMXFILES)
-	$(OCAMLOPT_CMD) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^ \
-	  -I ../runtime
+	$(OCAMLOPT_CMD) -o $@ -linkall $(LINKFLAGS) $(OCAMLDOC_NCLIBRARIES) $^
 
 $(OCAMLDOC_LIBCMA): $(LIBCMOFILES)
 	$(OCAMLC) -a -o $@ $(LINKFLAGS) $^

--- a/ocamldoc/Makefile.best_ocamldoc
+++ b/ocamldoc/Makefile.best_ocamldoc
@@ -16,15 +16,9 @@
 OCAMLDOC = $(ROOTDIR)/ocamldoc/ocamldoc$(EXE)
 OCAMLDOC_OPT = $(ROOTDIR)/ocamldoc/ocamldoc.opt$(EXE)
 
-ifeq "$(WITH_TSAN)" "true"
-OCAMLRUN_TO_USE = $(ROOTDIR)/runtime/ocamlrunt
-else
-OCAMLRUN_TO_USE = $(OCAMLRUN)
-endif
-
 ifeq "$(TARGET)" "$(HOST)"
   ifeq "$(SUPPORTS_SHARED_LIBRARIES)" "true"
-    OCAMLDOC_RUN_BYTE = $(OCAMLRUN_TO_USE) -I $(ROOTDIR)/otherlibs/unix \
+    OCAMLDOC_RUN_BYTE = $(OCAMLRUN) -I $(ROOTDIR)/otherlibs/unix \
                                     -I $(ROOTDIR)/otherlibs/str ./$(OCAMLDOC)
   else
     # if shared-libraries are not supported, unix.cma and str.cma
@@ -33,7 +27,7 @@ ifeq "$(TARGET)" "$(HOST)"
     OCAMLDOC_RUN_BYTE = ./$(OCAMLDOC)
   endif
 else
-  OCAMLDOC_RUN_BYTE = $(OCAMLRUN_TO_USE) ./$(OCAMLDOC)
+  OCAMLDOC_RUN_BYTE = $(OCAMLRUN) ./$(OCAMLDOC)
 endif
 
 OCAMLDOC_RUN_OPT = ./$(OCAMLDOC_OPT)

--- a/ocamltest/Makefile
+++ b/ocamltest/Makefile
@@ -210,7 +210,7 @@ $(eval $(call PROGRAM_SYNONYM,ocamltest))
 ocamltest_unix.%: flags+=$(unix_include) -opaque
 
 ocamltest$(EXE): $(deps_byte) $(bytecode_modules)
-	$(ocamlc_cmd) -I ../runtime $(unix_include)-custom -o $@ $^
+	$(ocamlc_cmd) $(unix_include)-custom -o $@ $^
 
 %.cmo: %.ml $(deps_byte)
 	$(ocamlc) -c $<
@@ -218,7 +218,7 @@ ocamltest$(EXE): $(deps_byte) $(bytecode_modules)
 $(eval $(call PROGRAM_SYNONYM,ocamltest.opt))
 
 ocamltest.opt$(EXE): $(deps_opt) $(native_modules)
-	$(ocamlopt_cmd) $(unix_include)-o $@ $^ -I ../runtime
+	$(ocamlopt_cmd) $(unix_include)-o $@ $^
 
 %.cmx: %.ml $(deps_opt)
 	$(ocamlopt) -c $<

--- a/ocamltest/builtin_actions.ml
+++ b/ocamltest/builtin_actions.ml
@@ -193,6 +193,12 @@ let tsan = make
      "tsan available"
      "tsan not available")
 
+let no_tsan = make
+  "no-tsan"
+  (Actions_helpers.pass_or_skip (not Ocamltest_config.tsan)
+     "tsan not available"
+     "tsan available")
+
 let has_symlink = make
   "has_symlink"
   (Actions_helpers.pass_or_skip (Unix.has_symlink () )
@@ -318,4 +324,5 @@ let _ =
     file_exists;
     copy;
     tsan;
+    no_tsan;
   ]

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -149,10 +149,5 @@ include $(addprefix $(DEPDIR)/, $(COBJS:.$(O)=.$(D)))
 endif
 endif
 
-ifeq "$(WITH_TSAN)" "true"
-OC_CFLAGS += $(OC_TSAN_CFLAGS)
-LINKOPTS += $(TSAN_RUNTIME_LIBS)
-endif
-
 $(DEPDIR)/%.$(D): %.c | $(DEPDIR)
-	$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $(TSAN_FLAGS) $< -MT '$*.$(O)' -MF $@
+	$(DEP_CC) $(OC_CPPFLAGS) $(CPPFLAGS) $< -MT '$*.$(O)' -MF $@

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -96,13 +96,13 @@ lib$(CLIBNAME)nat.$(A): $(COBJS)
 INSTALL_LIBDIR_LIBNAME = $(INSTALL_LIBDIR)/$(LIBNAME)
 
 install::
-	if test -f dll$(CLIBNAME).b$(EXT_DLL); then \
+	if test -f dll$(CLIBNAME)$(EXT_DLL); then \
 	  $(INSTALL_PROG) \
-	    dll$(CLIBNAME)$.b(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
+	    dll$(CLIBNAME)$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
 	fi
-	if test -f dll$(CLIBNAME).n$(EXT_DLL); then \
+	if test -f dll$(CLIBNAME)nat$(EXT_DLL); then \
 	  $(INSTALL_PROG) \
-	    dll$(CLIBNAME).n$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
+	    dll$(CLIBNAME)nat$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
 	fi
 ifneq "$(STUBSLIB_BYTECODE)" ""
 	$(INSTALL_DATA) $(STUBSLIB_BYTECODE) "$(INSTALL_LIBDIR)/"

--- a/otherlibs/Makefile.otherlibs.common
+++ b/otherlibs/Makefile.otherlibs.common
@@ -36,6 +36,10 @@ OPTCOMPFLAGS += -O3
 endif
 MKLIB=$(OCAMLRUN) $(ROOTDIR)/tools/ocamlmklib
 
+ifeq "$(WITH_TSAN)" "true"
+OC_NATIVE_CFLAGS += $(OC_TSAN_CFLAGS)
+endif
+
 # Variables that must be defined by individual libraries:
 # LIBNAME
 # CAMLOBJS
@@ -54,13 +58,14 @@ CLIBNAME ?= $(LIBNAME)
 ifeq "$(COBJS)" ""
 STUBSLIB=
 else
-STUBSLIB=lib$(CLIBNAME).$(A)
+STUBSLIB_BYTECODE=lib$(CLIBNAME).$(A)
+STUBSLIB_NATIVE=lib$(CLIBNAME)nat.$(A)
 endif
 
 .PHONY: all allopt opt.opt # allopt and opt.opt are synonyms
-all: $(STUBSLIB) $(LIBNAME).cma $(CMIFILES)
+all: $(STUBSLIB_BYTECODE) $(LIBNAME).cma $(CMIFILES)
 
-allopt: $(STUBSLIB) $(LIBNAME).cmxa $(LIBNAME).$(CMXS) $(CMIFILES)
+allopt: $(STUBSLIB_NATIVE) $(LIBNAME).cmxa $(LIBNAME).$(CMXS) $(CMIFILES)
 opt.opt: allopt
 
 $(LIBNAME).cma: $(CAMLOBJS)
@@ -75,25 +80,35 @@ $(LIBNAME).cmxa: $(CAMLOBJS_NAT)
 ifeq "$(COBJS)" ""
 	$(CAMLOPT) -o $@ -a -linkall $(CAMLOBJS_NAT) $(LINKOPTS)
 else
-	$(MKLIB) -o $(LIBNAME) -oc $(CLIBNAME) -ocamlopt '$(CAMLOPT)' -linkall \
+	$(MKLIB) -o $(LIBNAME) -oc $(CLIBNAME)nat -ocamlopt '$(CAMLOPT)' -linkall \
 	         $(CAMLOBJS_NAT) $(LINKOPTS)
 endif
 
-$(LIBNAME).cmxs: $(LIBNAME).cmxa $(STUBSLIB)
+$(LIBNAME).cmxs: $(LIBNAME).cmxa $(STUBSLIB_NATIVE)
 	$(CAMLOPT_CMD) -shared -o $(LIBNAME).cmxs -I . $(LIBNAME).cmxa
 
 lib$(CLIBNAME).$(A): $(COBJS)
-	$(MKLIB_CMD) -oc $(CLIBNAME) $(COBJS) $(LDOPTS)
+	$(MKLIB_CMD) -oc $(CLIBNAME) $(COBJS_BYTECODE) $(LDOPTS)
+
+lib$(CLIBNAME)nat.$(A): $(COBJS)
+	$(MKLIB_CMD) -oc $(CLIBNAME)nat $(COBJS_NATIVE) $(LDOPTS)
 
 INSTALL_LIBDIR_LIBNAME = $(INSTALL_LIBDIR)/$(LIBNAME)
 
 install::
-	if test -f dll$(CLIBNAME)$(EXT_DLL); then \
+	if test -f dll$(CLIBNAME).b$(EXT_DLL); then \
 	  $(INSTALL_PROG) \
-	    dll$(CLIBNAME)$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
+	    dll$(CLIBNAME)$.b(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
 	fi
-ifneq "$(STUBSLIB)" ""
-	$(INSTALL_DATA) $(STUBSLIB) "$(INSTALL_LIBDIR)/"
+	if test -f dll$(CLIBNAME).n$(EXT_DLL); then \
+	  $(INSTALL_PROG) \
+	    dll$(CLIBNAME).n$(EXT_DLL) "$(INSTALL_STUBLIBDIR)"; \
+	fi
+ifneq "$(STUBSLIB_BYTECODE)" ""
+	$(INSTALL_DATA) $(STUBSLIB_BYTECODE) "$(INSTALL_LIBDIR)/"
+endif
+ifneq "$(STUBSLIB_NATIVE)" ""
+	$(INSTALL_DATA) $(STUBSLIB_NATIVE) "$(INSTALL_LIBDIR)/"
 endif
 # If installing over a previous OCaml version, ensure the library is removed
 # from the previous installation.
@@ -143,9 +158,17 @@ distclean:: clean
 %.cmx: %.ml
 	$(CAMLOPT) -c $(COMPFLAGS) $(OPTCOMPFLAGS) $<
 
+%.b.$(O): %.c $(REQUIRED_HEADERS)
+	$(CC) -c $(OC_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) $(CPPFLAGS) \
+	  $(OUTPUTOBJ)$@ $<
+
+%.n.$(O): %.c $(REQUIRED_HEADERS)
+	$(CC) -c $(OC_CFLAGS) $(OC_NATIVE_CFLAGS) $(CFLAGS) $(OC_CPPFLAGS) \
+	  $(CPPFLAGS) $(OUTPUTOBJ)$@ $<
+
 ifeq "$(COMPUTE_DEPS)" "true"
-ifneq "$(COBJS)" ""
-include $(addprefix $(DEPDIR)/, $(COBJS:.$(O)=.$(D)))
+ifneq "$(COBJS_BYTECODE)" ""
+include $(addprefix $(DEPDIR)/, $(COBJS_BYTECODE:.b.$(O)=.$(D)))
 endif
 endif
 

--- a/otherlibs/runtime_events/Makefile
+++ b/otherlibs/runtime_events/Makefile
@@ -18,7 +18,9 @@
 LIBNAME=runtime_events
 CLIBNAME=camlruntime_events
 CAMLOBJS=runtime_events.cmo
-COBJS=runtime_events_consumer.$(O)
+COBJS_BYTECODE=runtime_events_consumer.b.$(O)
+COBJS_NATIVE=runtime_events_consumer.n.$(O)
+COBJS=$(COBJS_BYTECODE) $(COBJS_NATIVE)
 HEADERS=runtime_events_consumer.h
 
 include ../Makefile.otherlibs.common

--- a/otherlibs/str/Makefile
+++ b/otherlibs/str/Makefile
@@ -16,7 +16,9 @@
 # Makefile for the str library
 
 LIBNAME=str
-COBJS=strstubs.$(O)
+COBJS_BYTECODE=strstubs.b.$(O)
+COBJS_NATIVE=strstubs.n.$(O)
+COBJS=$(COBJS_BYTECODE) $(COBJS_NATIVE)
 CLIBNAME=camlstr
 CAMLOBJS=str.cmo
 

--- a/otherlibs/unix/Makefile
+++ b/otherlibs/unix/Makefile
@@ -71,7 +71,10 @@ endif
 
 ALL_C_SOURCES = $(COMMON_C_SOURCES) $(OS_C_SOURCES)
 
-COBJS = $(ALL_C_SOURCES:.c=.$(O))
+COBJS_BYTECODE = $(ALL_C_SOURCES:.c=.b.$(O))
+COBJS_NATIVE = $(ALL_C_SOURCES:.c=.n.$(O))
+
+COBJS = $(COBJS_BYTECODE) $(COBJS_NATIVE)
 
 CAMLOBJS=unix.cmo unixLabels.cmo
 

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -924,6 +924,17 @@ ENDFUNCTION(G(caml_callback_asm))
 
 FUNCTION(G(caml_callback2_asm))
 CFI_STARTPROC
+#if defined(WITH_THREAD_SANITIZER)
+    /* TSan enter function from C */
+        pushq   C_ARG_1
+        pushq   C_ARG_2
+        pushq   C_ARG_3
+        movq    24(%rsp), C_ARG_1
+        C_call  (GCALL(__tsan_func_entry))
+        popq    C_ARG_3
+        popq    C_ARG_2
+        popq    C_ARG_1
+#endif
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */
@@ -939,6 +950,17 @@ ENDFUNCTION(G(caml_callback2_asm))
 
 FUNCTION(G(caml_callback3_asm))
 CFI_STARTPROC
+#if defined(WITH_THREAD_SANITIZER)
+    /* TSan enter function from C */
+        pushq   C_ARG_1
+        pushq   C_ARG_2
+        pushq   C_ARG_3
+        movq    24(%rsp), C_ARG_1
+        C_call  (GCALL(__tsan_func_entry))
+        popq    C_ARG_3
+        popq    C_ARG_2
+        popq    C_ARG_1
+#endif
     /* Save callee-save registers */
         PUSH_CALLEE_SAVE_REGS
     /* Initial loading of arguments */

--- a/runtime/major_gc.c
+++ b/runtime/major_gc.c
@@ -618,6 +618,10 @@ Caml_inline void mark_stack_push_range(struct mark_stack* stk,
   me->end = end;
 }
 
+CAMLno_tsan /* FIXME TSan race reports from this function clog user programs,
+               so we disable instrumentation here. However, Further
+               investigation would be needed about the cause of these race
+               reports. */
 /* returns the work done by skipping unmarkable objects */
 static intnat mark_stack_push_block(struct mark_stack* stk, value block)
 {

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -28,7 +28,9 @@
 extern void __tsan_func_exit(void*);
 
 const char * __tsan_default_suppressions() {
-  return "deadlock:caml_plat_lock\n";
+  return "deadlock:caml_plat_lock\n"
+         "race:create_domain\n"
+    ;
 }
 
 void caml_tsan_exn_func_exit(uintnat pc, char* sp, char* trapsp)

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -67,10 +67,12 @@ void caml_tsan_exn_func_exit_c(char* limit)
 
   while (1) {
     const int ret = unw_step(&cursor);
-    CAMLassert(ret >= 0);
-    if (ret == 0) {
+    if (ret < 0) {
+      caml_fatal_error("libunwind function unw_step failed with code %d", ret);
+    } else if (ret == 0) { /* No more frames */
       break;
     }
+
 
     unw_get_reg(&cursor, UNW_REG_SP, &sp);
     __tsan_func_exit(NULL);

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -61,20 +61,27 @@ void caml_tsan_exn_func_exit_c(char* limit)
   unw_context_t uc;
   unw_cursor_t cursor;
   unw_word_t sp;
+  int ret;
 
-  unw_getcontext(&uc);
-  unw_init_local(&cursor, &uc);
+  ret = unw_getcontext(&uc);
+  if (ret != 0)
+      caml_fatal_error("unw_getcontextfailed failed with code %d", ret);
+  ret = unw_init_local(&cursor, &uc);
+  if (ret != 0)
+      caml_fatal_error("unw_init_local failed with code %d", ret);
 
   while (1) {
-    const int ret = unw_step(&cursor);
+    ret = unw_step(&cursor);
     if (ret < 0) {
-      caml_fatal_error("libunwind function unw_step failed with code %d", ret);
-    } else if (ret == 0) { /* No more frames */
+      caml_fatal_error("unw_step failed with code %d", ret);
+    } else if (ret == 0) {
+      /* No more frames */
       break;
     }
 
-
-    unw_get_reg(&cursor, UNW_REG_SP, &sp);
+    ret = unw_get_reg(&cursor, UNW_REG_SP, &sp);
+    if (ret != 0)
+      caml_fatal_error("unw_get_ret failed with code %d", ret);
     __tsan_func_exit(NULL);
 
     if ((char*)sp >= limit) {

--- a/stdlib/Makefile
+++ b/stdlib/Makefile
@@ -50,10 +50,6 @@ ifeq "$(INSTRUMENTED_RUNTIME)" "true"
 all: camlheaderi target_camlheaderi
 endif
 
-ifeq "$(WITH_TSAN)" "true"
-all: camlheadert target_camlheadert
-endif
-
 .PHONY: allopt opt.opt # allopt and opt.opt are synonyms
 allopt: stdlib.cmxa std_exit.cmx
 opt.opt: allopt
@@ -94,11 +90,6 @@ install::
 	$(INSTALL_DATA) target_camlheaderi "$(INSTALL_LIBDIR)/camlheaderi"
 endif
 
-ifeq "$(WITH_TSAN)" "true"
-install::
-	$(INSTALL_DATA) target_camlheadert "$(INSTALL_LIBDIR)/camlheadert"
-endif
-
 .PHONY: installopt
 installopt: installopt-default
 
@@ -136,8 +127,7 @@ TARGETHEADERPROGRAM = target_$(HEADERPROGRAM)
 CAMLHEADERS =\
   camlheader target_camlheader camlheader_ur \
   camlheaderd target_camlheaderd \
-  camlheaderi target_camlheaderi \
-  camlheadert target_camlheadert
+  camlheaderi target_camlheaderi
 
 # The % in pattern rules must always match something, hence the slightly strange
 # patterns and $(subst ...) since `camlheader%:` wouldn't match `camlheader`

--- a/testsuite/tests/backtrace/pr2195.ml
+++ b/testsuite/tests/backtrace/pr2195.ml
@@ -1,16 +1,17 @@
 (* TEST
+   * no-tsan
    flags += "-g"
    exit_status = "2"
-   * bytecode
+   ** bytecode
      ocamlrunparam += ",b=0"
      reference = "${test_source_directory}/pr2195-nolocs.byte.reference"
-   * bytecode
+   ** bytecode
      ocamlrunparam += ",b=1"
      reference = "${test_source_directory}/pr2195-nolocs.byte.reference"
-   * bytecode
+   ** bytecode
      ocamlrunparam += ",b=2"
      reference = "${test_source_directory}/pr2195-locs.byte.reference"
-   * native
+   ** native
      reference = "${test_source_directory}/pr2195.opt.reference"
      compare_programs = "false"
 *)

--- a/testsuite/tests/callback/test3.ml
+++ b/testsuite/tests/callback/test3.ml
@@ -1,9 +1,10 @@
 (* TEST
+   * no-tsan
    include unix
    modules = "test3_.c"
-   * libunix
-   ** bytecode
-   ** native
+   ** libunix
+   *** bytecode
+   *** native
 *)
 
 (* Tests nested calls from C (main C) to OCaml (main OCaml) to C (caml_to_c) to

--- a/testsuite/tests/lib-threads/mutex_errors.ml
+++ b/testsuite/tests/lib-threads/mutex_errors.ml
@@ -1,9 +1,10 @@
 (* TEST
 
 * hassysthreads
+** no-tsan
 include systhreads
-** bytecode
-** native
+*** bytecode
+*** native
 
 *)
 

--- a/testsuite/tests/misc/pr7168.ml
+++ b/testsuite/tests/misc/pr7168.ml
@@ -1,5 +1,7 @@
 (* TEST
 
+* no-tsan
+
 ocamlrunparam += "l=100000"
 *)
 

--- a/testsuite/tests/output-complete-obj/test.ml
+++ b/testsuite/tests/output-complete-obj/test.ml
@@ -1,28 +1,30 @@
 (* TEST
 
+* no-tsan
+
 readonly_files = "test.ml_stub.c"
 
-* setup-ocamlc.byte-build-env
-** ocamlc.byte
+** setup-ocamlc.byte-build-env
+*** ocamlc.byte
 flags = "-w -a -output-complete-obj"
 program = "test.ml.bc.${objext}"
-*** script
+**** script
 script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_bc_stub.exe \
                    test.ml.bc.${objext} ${nativecc_libs} test.ml_stub.c"
 output = "${compiler_output}"
-**** run
+***** run
 program = "./test.ml_bc_stub.exe"
 stdout = "program-output"
 stderr = "program-output"
-* setup-ocamlopt.byte-build-env
-** ocamlopt.byte
+** setup-ocamlopt.byte-build-env
+*** ocamlopt.byte
 flags = "-w -a -output-complete-obj"
 program = "test.ml.exe.${objext}"
-*** script
+**** script
 script = "${mkexe} -I${ocamlsrcdir}/runtime -o test.ml_stub.exe \
                    test.ml.exe.${objext} ${bytecc_libs} test.ml_stub.c"
 output = "${compiler_output}"
-**** run
+***** run
 program = "./test.ml_stub.exe"
 stdout = "program-output"
 stderr = "program-output"

--- a/testsuite/tests/runtime-errors/stackoverflow.ml
+++ b/testsuite/tests/runtime-errors/stackoverflow.ml
@@ -1,4 +1,5 @@
 (* TEST
+* no-tsan
 flags = "-w -a"
 ocamlrunparam += "l=100000"
 *)

--- a/testsuite/tests/tsan/exn_from_c.ml
+++ b/testsuite/tests/tsan/exn_from_c.ml
@@ -45,6 +45,7 @@ let [@inline never] f () =
   printf "leaving f\n%!"
 
 let () =
+  Printexc.record_backtrace true;
   let d = Domain.spawn (fun () -> Unix.sleep 1; r := 1) in
   f (); Unix.sleep 1;
   Domain.join d

--- a/testsuite/tests/tsan/exn_in_callback.ml
+++ b/testsuite/tests/tsan/exn_in_callback.ml
@@ -55,6 +55,7 @@ let [@inline never] f () =
   printf "leaving f\n%!"
 
 let () =
+  Printexc.record_backtrace true;
   let d = Domain.spawn (fun () -> Unix.sleep 1; r := 1) in
   f (); Unix.sleep 1;
   Domain.join d

--- a/testsuite/tests/tsan/exn_reraise.ml
+++ b/testsuite/tests/tsan/exn_reraise.ml
@@ -44,6 +44,7 @@ let [@inline never] f () =
   printf "leaving f\n%!"
 
 let () =
+  Printexc.record_backtrace true;
   let d = Domain.spawn (fun () -> Unix.sleep 1; r := 1) in
   f (); Unix.sleep 1;
   Domain.join d

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -64,8 +64,7 @@ $(programs_byte:%=%$(EXE)):
 	$(CAMLC) $(LINKFLAGS) -I $(ROOTDIR) -o $@ $(filter-out %.cmi,$^)
 
 $(programs_opt:%=%$(EXE)):
-	$(CAMLOPT_CMD) $(LINKFLAGS) -I $(ROOTDIR) -o $@ $(filter-out %.cmi,$^) \
-	  -I ../runtime
+	$(CAMLOPT_CMD) $(LINKFLAGS) -I $(ROOTDIR) -o $@ $(filter-out %.cmi,$^)
 
 clean::
 	rm -f $(programs_byte) $(programs_byte:%=%.exe)

--- a/utils/clflags.ml
+++ b/utils/clflags.ml
@@ -170,7 +170,7 @@ let pic_code = ref (match Config.architecture with (* -fPIC *)
 let runtime_variant =
   ref (match Config.force_instrumented_runtime with (* -runtime-variant *)
         | true -> "i"
-        | false -> if Config.tsan then "t" else "")
+        | false -> "")
 
 let with_runtime = ref true         (* -with-runtime *)
 


### PR DESCRIPTION
This is the result of the last month’s work. In an earlier PR #15, I wrote:

> However, instrumenting the default runtime is difficult without instrumenting ocamlrun; but instrumenting ocamlrun makes running bytecode a lot slower (something like 10x?), and since building the compiler relies mostly on ocamlrun, compiler build times jumps from ~2 min to more than an hour on my machine.
> 
> So the current compromise that we found is to use a separate, instrumented runtime and interpreter (resp. libasmrunt and ocamlrunt) and keep ocamlrun non instrumented. However, ocamlrun should only be used in the compiler build, and we make the compiler enforce this. We stay open to better solutions in the future.

A better solution has been found, thanks to @shindere’s advice: it turns out that it is easy to instrument native programs and not bytecode programs, as ocamlrun is created by linking it with a different set of object files than the runtime objects used to create native executables (namely `libcamlrun.a` and `libasmrun.a`, respectively).

In this PR we use this fact so that any TSan-related instrumentation is removed from the bytecode backend, and reserve it to the native backend. This simplifies the build process (notably by removing the TSan-specific runtime) and gets rid of a number of testsuite failures.

The rest of the commits improve the testsuite and/or fix bugs that it uncovered.