### PR TITLE
Disable unnecessary instrumentation for performance

### DIFF
--- a/asmcomp/cmm_helpers.ml
+++ b/asmcomp/cmm_helpers.ml
@@ -651,7 +651,8 @@ let non_profinfo_mask =
 let get_header ptr dbg =
   (* We cannot deem this as [Immutable] due to the presence of [Obj.truncate]
      and [Obj.set_tag]. *)
-  Cop(mk_load_mut Word_int,
+  Cop(
+    Cload {memory_chunk = Word_int; mutability = Immutable; is_atomic = false},
     [Cop(Cadda, [ptr; Cconst_int(-size_int, dbg)], dbg)], dbg)
 
 let get_header_without_profinfo ptr dbg =
@@ -668,8 +669,9 @@ let get_tag ptr dbg =
     Cop(Cand, [get_header ptr dbg; Cconst_int (255, dbg)], dbg)
   else                                  (* If byte loads are efficient *)
     (* Same comment as [get_header] above *)
-    Cop(mk_load_mut Byte_unsigned,
-        [Cop(Cadda, [ptr; Cconst_int(tag_offset, dbg)], dbg)], dbg)
+    Cop(
+      Cload {memory_chunk = Byte_unsigned; mutability = Immutable; is_atomic = false},
+      [Cop(Cadda, [ptr; Cconst_int(tag_offset, dbg)], dbg)], dbg)
 
 let get_size ptr dbg =
   Cop(Clsr, [get_header_without_profinfo ptr dbg; Cconst_int (10, dbg)], dbg)

--- a/runtime/caml/misc.h
+++ b/runtime/caml/misc.h
@@ -553,32 +553,6 @@ CAMLextern int caml_snwprintf(wchar_t * buf,
 #define snprintf_os snprintf
 #endif
 
-/* Macro used to deactivate thread and address sanitizers on some
-   functions. */
-#define CAMLno_tsan
-#define CAMLno_asan
-/* __has_feature is Clang-specific, but GCC defines __SANITIZE_ADDRESS__ and
- * __SANITIZE_THREAD__. */
-#if defined(__has_feature)
-#  if __has_feature(thread_sanitizer)
-#    undef CAMLno_tsan
-#    define CAMLno_tsan __attribute__((no_sanitize("thread")))
-#  endif
-#  if __has_feature(address_sanitizer)
-#    undef CAMLno_asan
-#    define CAMLno_asan __attribute__((no_sanitize("address")))
-#  endif
-#else
-#  if __SANITIZE_THREAD__
-#    undef CAMLno_tsan
-#    define CAMLno_tsan __attribute__((no_sanitize("thread")))
-#  endif
-#  if __SANITIZE_ADDRESS__
-#    undef CAMLno_asan
-#    define CAMLno_asan __attribute__((no_sanitize("address")))
-#  endif
-#endif
-
 #endif /* CAML_INTERNALS */
 
 /* The [backtrace_slot] type represents values stored in

--- a/runtime/minor_gc.c
+++ b/runtime/minor_gc.c
@@ -167,6 +167,7 @@ static void spin_on_header(value v) {
   }
 }
 
+CAMLno_tsan /* Disable TSan instrumentation for performance. */
 Caml_inline header_t get_header_val(value v) {
   header_t hd = atomic_load_explicit(Hp_atomic_val(v), memory_order_acquire);
   if (!Is_update_in_progress(hd))
@@ -386,6 +387,7 @@ void oldify_one (void* st_v, value v, volatile value *p)
    Note that [oldify_one] itself is called by oldify_mopup, so we
    have to be careful to remove the first entry from the list before
    oldifying its fields. */
+CAMLno_tsan /* Disable TSan instrumentation for performance. */
 static void oldify_mopup (struct oldify_state* st, int do_ephemerons)
 {
   value v, new_v, f;

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -250,6 +250,7 @@ Caml_inline void pool_initialize(pool* r,
 }
 
 /* Allocating an object from a pool */
+CAMLno_tsan /* Disable TSan instrumentation for performance. */
 static intnat pool_sweep(struct caml_heap_state* local,
                          pool**,
                          sizeclass sz ,

--- a/runtime/str.c
+++ b/runtime/str.c
@@ -268,6 +268,7 @@ CAMLprim value caml_bytes_set64(value str, value index, value newval)
   return Val_unit;
 }
 
+CAMLno_tsan
 CAMLprim value caml_string_equal(value s1, value s2)
 {
   mlsize_t sz1, sz2;


### PR DESCRIPTION
This PR proposes to:
- Stop instrumenting header loads in the generated executables. This should be safe, see https://github.com/ocaml/ocaml/issues/10942.
- Stop instrumenting a number of runtime functions that don’t need to be instrumented for TSan to detect data races in user programs (assuming correctness of the runtime).

Preliminary benchmarks suggest that this turns a 13x slowdown into ~12x on mutation-intensive programs, and into ~7x on programs with very little mutation.