### PR TITLE
Fix build on macOS

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -177,6 +177,7 @@ INSTALL_SOURCE_ARTIFACTS=@install_source_artifacts@
 
 OC_CFLAGS=@oc_cflags@
 OC_TSAN_CFLAGS=@oc_tsan_cflags@
+OC_TSAN_LDFLAGS=@oc_tsan_ldflags@
 OC_TSAN_ASPPFLAGS=@oc_tsan_asppflags@
 OC_TSAN_CPPFLAGS=@oc_tsan_cppflags@
 CFLAGS=@CFLAGS@

--- a/configure
+++ b/configure
@@ -16406,7 +16406,7 @@ then :
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: using thread sanitizer with vendor=$ocaml_cv_cc_vendor" >&5
 printf "%s\n" "$as_me: using thread sanitizer with vendor=$ocaml_cv_cc_vendor" >&6;}
   case $ocaml_cv_cc_vendor in #(
-  gcc-[0123456789]-*|gcc-10-*) :
+  gcc-[0123456789]-*|gcc-10-*|clang-*) :
      ;; #(
   *) :
     oc_tsan_cflags="$oc_tsan_cflags -Wno-tsan" ;;

--- a/configure
+++ b/configure
@@ -863,6 +863,7 @@ oc_ldflags
 oc_cppflags
 oc_tsan_cppflags
 oc_tsan_asppflags
+oc_tsan_ldflags
 oc_tsan_cflags
 oc_cflags
 toolchain
@@ -3231,6 +3232,7 @@ ocamlc_cppflags=""
 oc_ldflags=""
 oc_dll_ldflags=""
 oc_tsan_cflags="-O1 -fno-omit-frame-pointer -fsanitize=thread"
+oc_tsan_ldflags=""
 oc_tsan_cppflags="-DWITH_THREAD_SANITIZER"
 oc_tsan_asppflags="-DWITH_THREAD_SANITIZER"
 oc_exe_ldflags=""
@@ -3296,6 +3298,7 @@ OCAML_VERSION_SHORT=5.1
 # Note: This is present for the flexdll bootstrap where it exposed as the old
 # TOOLPREF variable. It would be better if flexdll where updated to require
 # WINDRES instead.
+
 
 
 
@@ -16412,6 +16415,16 @@ else $as_nop
   { printf "%s\n" "$as_me:${as_lineno-$LINENO}: not using thread sanitizer" >&5
 printf "%s\n" "$as_me: not using thread sanitizer" >&6;}
 
+fi
+
+if $tsan
+then :
+  case $target in #(
+  *-apple-darwin*) :
+     ;; #(
+  *) :
+    oc_tsan_ldflags="-lunwind" ;;
+esac
 fi
 
 ## Sockets

--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,7 @@ ocamlc_cppflags=""
 oc_ldflags=""
 oc_dll_ldflags=""
 oc_tsan_cflags="-O1 -fno-omit-frame-pointer -fsanitize=thread"
+oc_tsan_ldflags=""
 oc_tsan_cppflags="-DWITH_THREAD_SANITIZER"
 oc_tsan_asppflags="-DWITH_THREAD_SANITIZER"
 oc_exe_ldflags=""
@@ -138,6 +139,7 @@ AC_SUBST([ccomptype])
 AC_SUBST([toolchain])
 AC_SUBST([oc_cflags])
 AC_SUBST([oc_tsan_cflags])
+AC_SUBST([oc_tsan_ldflags])
 AC_SUBST([oc_tsan_asppflags])
 AC_SUBST([oc_tsan_cppflags])
 AC_SUBST([oc_cppflags])
@@ -1583,6 +1585,14 @@ AS_IF([$tsan],
     [],
     [oc_tsan_cflags="$oc_tsan_cflags -Wno-tsan"])],
   [AC_MSG_NOTICE([not using thread sanitizer])]
+)
+
+AS_IF([$tsan],
+  [AS_CASE([$target],
+    [*-apple-darwin*],
+    [],
+    [oc_tsan_ldflags="-lunwind"])],
+  []
 )
 
 ## Sockets

--- a/configure.ac
+++ b/configure.ac
@@ -1579,7 +1579,7 @@ AS_IF([test "x$enable_tsan" = "xyes" ],
 AS_IF([$tsan],
   [AC_MSG_NOTICE([using thread sanitizer with vendor=$ocaml_cv_cc_vendor])
   AS_CASE([$ocaml_cv_cc_vendor],
-    [gcc-[[0123456789]]-*|gcc-10-*],
+    [gcc-[[0123456789]]-*|gcc-10-*|clang-*],
     [],
     [oc_tsan_cflags="$oc_tsan_cflags -Wno-tsan"])],
   [AC_MSG_NOTICE([not using thread sanitizer])]

--- a/driver/optmaindriver.ml
+++ b/driver/optmaindriver.ml
@@ -49,8 +49,11 @@ let main argv ppf =
     Compmisc.read_clflags_from_env ();
     if !Clflags.plugin then
       Compenv.fatal "-plugin is only supported up to OCaml 4.08.0";
-    if Config.tsan then
-      Compenv.(defer (ProcessObjects ["-fsanitize=thread"; "-lunwind"]));
+    if Config.tsan then begin
+      Compenv.(defer (ProcessObjects ["-fsanitize=thread"]));
+      if String.length Config.tsan_ld_flags <> 0 then
+        Compenv.(defer (ProcessObjects [Config.tsan_ld_flags]))
+    end;
     begin try
       Compenv.process_deferred_actions
         (ppf,

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -30,6 +30,12 @@
 #endif
 
 extern void __tsan_func_exit(void*);
+#if defined(__GNUC__) && !defined(__clang__)
+/* GCC already has __tsan_func_entry declared for some reason */
+#else
+extern void __tsan_func_entry(void*);
+#endif
+
 
 const char * __tsan_default_suppressions() {
   return "deadlock:caml_plat_lock\n"

--- a/utils/config.common.ml
+++ b/utils/config.common.ml
@@ -118,6 +118,7 @@ let configuration_variables =
   p_bool "function_sections" function_sections;
   p_bool "afl_instrument" afl_instrument;
   p_bool "tsan" tsan;
+  p "tsan_ld_flags" tsan_ld_flags;
   p_bool "windows_unicode" windows_unicode;
   p_bool "supports_shared_libraries" supports_shared_libraries;
   p_bool "naked_pointers" naked_pointers;

--- a/utils/config.fixed.ml
+++ b/utils/config.fixed.ml
@@ -51,6 +51,7 @@ let flat_float_array = true
 let function_sections = false
 let afl_instrument = false
 let tsan = false
+let tsan_ld_flags = ""
 let architecture = "none"
 let model = "default"
 let system = "unknown"

--- a/utils/config.generated.ml.in
+++ b/utils/config.generated.ml.in
@@ -108,3 +108,4 @@ let systhread_supported = @systhread_support@
 let flexdll_dirs = [@flexdll_dir@]
 
 let tsan = @tsan@
+let tsan_ld_flags = {@QS@|@oc_tsan_ldflags@|@QS@}

--- a/utils/config.mli
+++ b/utils/config.mli
@@ -245,6 +245,10 @@ val afl_instrument : bool
 val tsan : bool
 (** Whether ThreadSanitizer instrumentation is enabled *)
 
+val tsan_ld_flags : string
+(* Flags to pass to the system linker when build ThreadSanitizer-instrumented
+   programs *)
+
 
 (** Access to configuration values *)
 val print_config : out_channel -> unit


### PR DESCRIPTION
Build failures were due to clang, and idiosyncracies of libunwind on macOS, which does not require the `-lunwind` linking flag.