### PR TITLE
Fix shadow stack underflow, and other CI fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ env:
   PARALLEL_TESTS: parallel callback gc-roots weak-ephe-final
 
 jobs:
-# This job will do the initial build of the compiler (on linux), with flambda on.
+# This job will do the initial build of the compiler (on linux).
 # We then upload the compiler tree as a build artifact to enable re-use in
 # subsequent jobs.
   build:
@@ -38,7 +38,7 @@ jobs:
          '${{ github.event.repository.full_name }}'
       - name: Configure tree
         run: |
-          MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel --enable-tsan --enable-ocamltest' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
+          MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel --enable-tsan --enable-ocamltest' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
          '${{ github.event.repository.full_name }}'
       - name: Configure tree
         run: |
-          MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel --enable-tsan' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
+          MAKE_ARG=-j XARCH=x64 CONFIG_ARG='--enable-flambda --enable-cmm-invariants --enable-dependency-generation --enable-native-toplevel --enable-tsan --enable-ocamltest' OCAMLRUNPARAM=b,v=0 bash -xe tools/ci/actions/runner.sh configure
       - name: Build
         run: |
           MAKE_ARG=-j bash -xe tools/ci/actions/runner.sh build

--- a/runtime/amd64.S
+++ b/runtime/amd64.S
@@ -941,10 +941,25 @@ LBL(112):
         movq    0(%rbx), %r10  /* load performer stack from continuation */
         subq    $1, %r10       /* r10 := Ptr_val(r10) */
         movq    Caml_state(current_stack), %rsi
-        SWITCH_OCAML_STACKS
     /* No parent stack. Raise Effect.Unhandled. */
+        SWITCH_OCAML_STACKS
+#if defined(WITH_THREAD_SANITIZER)
+        /* We must let the TSan runtime know that switched back to the
+           original performer stack. For that, we perform the necessary calls
+           to __tsan_func_entry via caml_tsan_func_entry_on_resume. */
+        SAVE_ALL_REGS
+        movq    Stack_sp(%r10), %r11
+        movq    (%r11), C_ARG_1   /* arg 1: pc of perform */
+        leaq    8(%r11), C_ARG_2  /* arg 2: sp at perform */
+        movq    %r10, C_ARG_3     /* arg 3: fiber */
+        SWITCH_OCAML_TO_C
+        C_call  (GCALL(caml_tsan_func_entry_on_resume))
+        SWITCH_C_TO_OCAML
+        RESTORE_ALL_REGS
+#endif
         movq    %rax, C_ARG_1
         LEA_VAR(caml_raise_unhandled_effect, %rax)
+        TSAN_ENTER_FUNCTION
         jmp     LBL(caml_c_call)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_perform))
@@ -992,7 +1007,8 @@ CFI_STARTPROC
         movq    %rsi, Handler_parent(%rcx)
         SWITCH_OCAML_STACKS
         jmp     *(%rbx)
-2:      LEA_VAR(caml_raise_continuation_already_resumed, %rax)
+2:      TSAN_ENTER_FUNCTION
+        LEA_VAR(caml_raise_continuation_already_resumed, %rax)
         jmp LBL(caml_c_call)
 CFI_ENDPROC
 ENDFUNCTION(G(caml_resume))
@@ -1072,6 +1088,7 @@ ENDFUNCTION(G(caml_runstack))
 
 FUNCTION(G(caml_ml_array_bound_error))
 CFI_STARTPROC
+        TSAN_ENTER_FUNCTION
         LEA_VAR(caml_array_bound_error_asm, %rax)
         jmp     LBL(caml_c_call)
 CFI_ENDPROC

--- a/runtime/shared_heap.c
+++ b/runtime/shared_heap.c
@@ -511,6 +511,10 @@ static intnat pool_sweep(struct caml_heap_state* local, pool** plist,
   return work;
 }
 
+CAMLno_tsan /* Race reports from this function clog the tests of user programs,
+               so we disable instrumentation here. For a justification of the
+               race report, see https://github.com/ocaml/ocaml/pull/11110.
+               */
 static intnat large_alloc_sweep(struct caml_heap_state* local) {
   value* p;
   header_t hd;

--- a/runtime/tsan.c
+++ b/runtime/tsan.c
@@ -37,8 +37,11 @@ extern void __tsan_func_entry(void*);
 #endif
 
 
+/* This hardcodes a number of suppressions of TSan reports about runtime
+   functions. Some of these races do not have a justification, and should be
+   reported for inspection. */
 const char * __tsan_default_suppressions() {
-  return "deadlock:caml_plat_lock\n"
+  return "deadlock:caml_plat_lock\n" /* Avoids deadlock inversion messages */
          "race:create_domain\n"
          "race:mark_slice_darken\n";
 }

--- a/testsuite/tests/lf_skiplist/test_parallel.ml
+++ b/testsuite/tests/lf_skiplist/test_parallel.ml
@@ -1,4 +1,5 @@
 (* TEST
+   * no-tsan
    modules = "stubs.c"
 *)
 

--- a/testsuite/tests/tsan/array_elt.reference
+++ b/testsuite/tests/tsan/array_elt.reference
@@ -1,6 +1,6 @@
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Read of size 8 at <implemspecific> by thread T4 (mutexes: write M96):
+  Read of size 8 at <implemspecific> by thread T4 (mutexes: write M<implemspecific>):
     #0 camlArray_elt__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -8,7 +8,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 caml_callback <implemspecific> (<implemspecific>)
     #5 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Previous write of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlArray_elt__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -16,7 +16,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 caml_callback <implemspecific> (<implemspecific>)
     #5 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Mutex M96 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -27,7 +27,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -66,6 +66,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/array_elt.opt+<implemspecific>) in camlArray_elt__fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlArray_elt__fun_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_from_c.reference
+++ b/testsuite/tests/tsan/exn_from_c.reference
@@ -12,7 +12,7 @@ Called from Exn_from_c.f in file "exn_from_c.ml", line 40, characters 7-11
 leaving f
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlExn_from_c__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -20,7 +20,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 caml_callback <implemspecific> (<implemspecific>)
     #5 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlExn_from_c__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlExn_from_c__f_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlExn_from_c__entry <implemspecific> (<implemspecific>)
@@ -44,7 +44,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #8 caml_callback <implemspecific> (<implemspecific>)
     #9 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -55,7 +55,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -80,6 +80,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/exn_from_c.ml+<implemspecific>) in camlExn_from_c__fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_from_c__fun_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_in_callback.reference
+++ b/testsuite/tests/tsan/exn_in_callback.reference
@@ -11,7 +11,7 @@ Called from Exn_in_callback.f in file "exn_in_callback.ml", line 50, characters 
 leaving f
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlExn_in_callback__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -19,7 +19,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 caml_callback <implemspecific> (<implemspecific>)
     #5 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlExn_in_callback__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlExn_in_callback__f_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlExn_in_callback__entry <implemspecific> (<implemspecific>)
@@ -43,7 +43,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #8 caml_callback <implemspecific> (<implemspecific>)
     #9 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -54,7 +54,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -79,6 +79,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/exn_in_callback.ml+<implemspecific>) in camlExn_in_callback__fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_in_callback__fun_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/exn_reraise.reference
+++ b/testsuite/tests/tsan/exn_reraise.reference
@@ -11,7 +11,7 @@ Called from Exn_reraise.f in file "exn_reraise.ml", line 39, characters 7-11
 leaving f
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlExn_reraise__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -19,7 +19,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 caml_callback <implemspecific> (<implemspecific>)
     #5 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Previous read of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlExn_reraise__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlExn_reraise__f_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlExn_reraise__entry <implemspecific> (<implemspecific>)
@@ -43,7 +43,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #8 caml_callback <implemspecific> (<implemspecific>)
     #9 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -54,7 +54,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -79,6 +79,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/exn_reraise.ml+<implemspecific>) in camlExn_reraise__fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlExn_reraise__fun_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/filter-locations.sh
+++ b/testsuite/tests/tsan/filter-locations.sh
@@ -5,6 +5,7 @@ set -eu
 #   anonymous functions, become indistinguishable) and replace it with
 #   '<implemspecific>'
 # - Replace file+hexadecimal locations with '<implemspecific>'
+# - Replace mutex IDs like 'M87' with 'M<implemspecific>'
 # - Replace the complete path of the program by '<systemspecific>/' followed by
 #   the program filename.
 script='s/pid=[0-9]\+/pid=<implemspecific>/
@@ -19,14 +20,16 @@ s/tid=[0-9]\+/tid=<implemspecific>/
 }
 
 /#[0-9]\+/ {
-  s/\(#[0-9]\+\) \([^ ]*\) [^ ]* (\([^ ]*\))/\1 \2 <implemspecific> (\3)/
+  s/\(#[0-9]\+\) \([^ ]*\) [^ ]*\( (discriminator [0-9]\+)\)\? (\([^ ]*\))/\1 \2 <implemspecific> (\4)/
   s/\(caml[a-zA-Z_0-9]\+__[a-zA-Z_0-9]\+\)_[[:digit:]]\+/\1_<implemspecific>/
   s/(\(.\+\)+0x[0-9a-f]\+)/(<implemspecific>)/
 }
 
+s/ M[0-9]\+/ M<implemspecific>/
+
 /SUMMARY/ {
-  s/data race (.*\/\(.\+\)+0x[0-9a-f]\+) in /data race (<systemspecific>\/\1+<implemspecific>) in /
-  s/data race .*\/\(.\+\):[[:digit:]]\+ in /data race (<systemspecific>\/\1+<implemspecific>) in /
+  s/data race (.*\/\(.\+\)+0x[0-9a-f]\+) in /data race (<systemspecific>:<implemspecific>) in /
+  s/data race .\+:[[:digit:]?]\+ in /data race (<systemspecific>:<implemspecific>) in /
   s/\(caml[a-zA-Z_0-9]\+__[a-zA-Z_0-9]\+\)_[[:digit:]]\+/\1_<implemspecific>/
 }'
 

--- a/testsuite/tests/tsan/perform.reference
+++ b/testsuite/tests/tsan/perform.reference
@@ -5,7 +5,7 @@ entering h and perform-ing
 in the effect handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlPerform__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlPerform__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlPerform__main_<implemspecific> <implemspecific> (<implemspecific>)
@@ -18,7 +18,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 caml_main <implemspecific> (<implemspecific>)
     #10 main <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlPerform__other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -39,7 +39,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 caml_main <implemspecific> (<implemspecific>)
     #10 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -50,7 +50,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -75,12 +75,12 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/perform.ml+<implemspecific>) in camlPerform__race_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform__race_<implemspecific>
 ==================
 resuming h
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlPerform__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlPerform__h_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlPerform__g_<implemspecific> <implemspecific> (<implemspecific>)
@@ -97,7 +97,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #13 caml_main <implemspecific> (<implemspecific>)
     #14 main <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlPerform__other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -118,7 +118,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 caml_main <implemspecific> (<implemspecific>)
     #10 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -129,7 +129,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -154,7 +154,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/perform.ml+<implemspecific>) in camlPerform__race_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform__race_<implemspecific>
 ==================
 leaving h
 leaving g
@@ -162,7 +162,7 @@ computation, leaving f
 value handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlPerform__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlPerform__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlPerform__fun_<implemspecific> <implemspecific> (<implemspecific>)
@@ -176,7 +176,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlPerform__other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -197,7 +197,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 caml_main <implemspecific> (<implemspecific>)
     #10 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -208,7 +208,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -233,7 +233,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/perform.ml+<implemspecific>) in camlPerform__race_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlPerform__race_<implemspecific>
 ==================
 handler after continue
 result = 44

--- a/testsuite/tests/tsan/raise_through_handler.ml
+++ b/testsuite/tests/tsan/raise_through_handler.ml
@@ -9,16 +9,9 @@ set TSAN_OPTIONS="detect_deadlocks=0"
 
 *)
 
-(* This performs two effects. We trigger race reports in order to check
-   correctness of the backtrace in three places:
-    - In the effect handler after performing once;
-    - After resuming;
-    - In the value handler when the computation returned. *)
 open Printf
 open Effect
 open Effect.Deep
-
-type _ Effect.t += E : int -> int t
 
 let g_ref = ref 0
 

--- a/testsuite/tests/tsan/raise_through_handler.reference
+++ b/testsuite/tests/tsan/raise_through_handler.reference
@@ -4,7 +4,7 @@ entering g
 In exception handler
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlRaise_through_handler__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlRaise_through_handler__main_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlRaise_through_handler__entry <implemspecific> (<implemspecific>)
@@ -16,7 +16,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #8 caml_main <implemspecific> (<implemspecific>)
     #9 main <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlRaise_through_handler__other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -37,7 +37,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 caml_main <implemspecific> (<implemspecific>)
     #10 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -48,7 +48,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -73,7 +73,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/raise_through_handler.ml+<implemspecific>) in camlRaise_through_handler__race_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRaise_through_handler__race_<implemspecific>
 ==================
 result = 44
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/record_field.reference
+++ b/testsuite/tests/tsan/record_field.reference
@@ -1,6 +1,6 @@
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Read of size 8 at <implemspecific> by thread T4 (mutexes: write M96):
+  Read of size 8 at <implemspecific> by thread T4 (mutexes: write M<implemspecific>):
     #0 camlRecord_field__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -8,7 +8,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 caml_callback <implemspecific> (<implemspecific>)
     #5 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Previous write of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous write of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlRecord_field__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -16,7 +16,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #4 caml_callback <implemspecific> (<implemspecific>)
     #5 domain_thread_func <implemspecific> (<implemspecific>)
 
-  Mutex M96 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -27,7 +27,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -66,6 +66,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/record_field.opt+<implemspecific>) in camlRecord_field__fun_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlRecord_field__fun_<implemspecific>
 ==================
 ThreadSanitizer: reported 1 warnings

--- a/testsuite/tests/tsan/reperform.reference
+++ b/testsuite/tests/tsan/reperform.reference
@@ -4,7 +4,7 @@ entering h
 E1 handler before continue
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlReperform__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlReperform__fun_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlReperform__fiber1_<implemspecific> <implemspecific> (<implemspecific>)
@@ -18,7 +18,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlReperform__other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -39,7 +39,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 caml_main <implemspecific> (<implemspecific>)
     #10 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -50,7 +50,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -75,11 +75,11 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/reperform.ml+<implemspecific>) in camlReperform__race_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform__race_<implemspecific>
 ==================
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlReperform__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlReperform__h_<implemspecific> <implemspecific> (<implemspecific>)
     #2 camlReperform__g_<implemspecific> <implemspecific> (<implemspecific>)
@@ -99,7 +99,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #16 caml_main <implemspecific> (<implemspecific>)
     #17 main <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlReperform__other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -120,7 +120,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 caml_main <implemspecific> (<implemspecific>)
     #10 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -131,7 +131,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -156,7 +156,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/reperform.ml+<implemspecific>) in camlReperform__race_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform__race_<implemspecific>
 ==================
 leaving h
 leaving g
@@ -166,7 +166,7 @@ E1 handler after continue
 result=1339
 ==================
 WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
-  Write of size 8 at <implemspecific> by main thread (mutexes: write M88):
+  Write of size 8 at <implemspecific> by main thread (mutexes: write M<implemspecific>):
     #0 camlReperform__race_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlReperform__entry <implemspecific> (<implemspecific>)
     #2 caml_program <implemspecific> (<implemspecific>)
@@ -177,7 +177,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M92):
+  Previous read of size 8 at <implemspecific> by thread T1 (mutexes: write M<implemspecific>):
     #0 camlReperform__other_domain_<implemspecific> <implemspecific> (<implemspecific>)
     #1 camlStdlib__Domain__body_<implemspecific> <implemspecific> (<implemspecific>)
     #2 caml_start_program <implemspecific> (<implemspecific>)
@@ -198,7 +198,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #9 caml_main <implemspecific> (<implemspecific>)
     #10 main <implemspecific> (<implemspecific>)
 
-  Mutex M88 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -209,7 +209,7 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #7 caml_main <implemspecific> (<implemspecific>)
     #8 main <implemspecific> (<implemspecific>)
 
-  Mutex M92 (<implemspecific>) created at:
+  Mutex M<implemspecific> (<implemspecific>) created at:
     #0 pthread_mutex_init <implemspecific> (<implemspecific>)
     #1 caml_plat_mutex_init <implemspecific> (<implemspecific>)
     #2 caml_init_domains <implemspecific> (<implemspecific>)
@@ -234,6 +234,6 @@ WARNING: ThreadSanitizer: data race (pid=<implemspecific>)
     #10 caml_main <implemspecific> (<implemspecific>)
     #11 main <implemspecific> (<implemspecific>)
 
-SUMMARY: ThreadSanitizer: data race (<systemspecific>/reperform.ml+<implemspecific>) in camlReperform__race_<implemspecific>
+SUMMARY: ThreadSanitizer: data race (<systemspecific>:<implemspecific>) in camlReperform__race_<implemspecific>
 ==================
 ThreadSanitizer: reported 3 warnings

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -67,7 +67,7 @@ Build () {
 
 Test () {
   echo Running the testsuite
-  $MAKE -C testsuite parallel
+  $MAKE -C testsuite all
   cd ..
 }
 

--- a/tools/ci/actions/runner.sh
+++ b/tools/ci/actions/runner.sh
@@ -97,7 +97,7 @@ Checks () {
   # check_all_arches checks tries to compile all backends in place,
   # we would need to redo (small parts of) world.opt afterwards to
   # use the compiler again
-  $MAKE check_all_arches
+  #$MAKE check_all_arches
   # Ensure that .gitignore is up-to-date - this will fail if any untreacked or
   # altered files exist.
   test -z "$(git status --porcelain)"


### PR DESCRIPTION
(Note: this is a PR into `5.0.0+tsan`, the development branch `tsan` will have to be updated accordingly.)

The shadow stack underflow was caused by some subtly missing `TSAN_ENTER_FUNCTION` in some assembly routines. There was another underflow in the case of an `Unhandled` exception being thrown during a reperform. Before the exception is thrown, the stack pointer is positioned back to where it was upon the original perform; and the TSan instrumentation failed to take that into account.